### PR TITLE
Rename org to 'redhat-best-practices-for-k8s'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # oct - Offline Catalog Tool for Red Hat's certified containerized artifacts
-OCT is a containerized application that retrieves the latest certified artifacts (operators, containers and helm charts) from the [Red Hat's online catalog](https://catalog.redhat.com/api/containers/v1/ui/) to be used by RH's certification tools like [TNF](https://github.com/test-network-function/cnf-certification-test) or similar.
+OCT is a containerized application that retrieves the latest certified artifacts (operators, containers and helm charts) from the [Red Hat's online catalog](https://catalog.redhat.com/api/containers/v1/ui/) to be used by RH's certification tools like [TNF](https://github.com/redhat-best-practices-for-k8s/certsuite) or similar.
 
 # Important
-This is a Work in Progress PoC/demo project, not a complete/GA nor a ready to use tool. Most of the code was copied from the [TNF repo](https://github.com/test-network-function/cnf-certification-test) in order to get a running code quickly.
+This is a Work in Progress PoC/demo project, not a complete/GA nor a ready to use tool. Most of the code was copied from the [TNF repo](https://github.com/redhat-best-practices-for-k8s/certsuite) in order to get a running code quickly.
 
 # Motivation
 ## Completely disconnected environments issue
@@ -89,7 +89,7 @@ TNF's fetch CLI tool code was copied here, so the syntax is the same, but it's h
       ```
 
 # How it works
-The `oct` container has a script [run.sh](https://github.com/test-network-function/oct/blob/main/scripts/run.sh) that will run the TNF's `fetch` command. If it succeeds, the db files are copied into the container's `/tmp/dump` folder. The `OCT_DUMP_ONLY` env var is used to bypass the call to `fetch` so the current content of the container's db is copied into /tmp/dump.
+The `oct` container has a script [run.sh](https://github.com/redhat-best-practices-for-k8s/oct/blob/main/scripts/run.sh) that will run the TNF's `fetch` command. If it succeeds, the db files are copied into the container's `/tmp/dump` folder. The `OCT_DUMP_ONLY` env var is used to bypass the call to `fetch` so the current content of the container's db is copied into /tmp/dump.
 
 The `fetch` tool was updated in this repo to retrieve the operator and container pages in a concurrent way, using a go routine for each http get. I did this modification to speed up the dev tests, as the original `fetch` implementation to the the sequantial retrieval of catalog pages was too slow (RH's online catalog takes a lot of time for each response). Do not pay too much attention to the current implementation, as the original `fetch` tool's code was copied some weeks ago, and it was modified later by some PRs in the TNF's repo.
 # Issues/Caveats/Warnings
@@ -101,6 +101,6 @@ The current TNF's `fetch` tool (used in `oct`) works like this:
 3. The current workflow to create a new `oct` container has two issues:
    - The catalog API to get the certified containers is not working quite well lately, so the workflow fails too many times.
    - The workflow uses the `fetch`tool directly, but the repo's db index is empty, so it will always create a new container, no matter if it contains exactly the same files as the latest one. This can easily be solved by improving the workflow to dump the latest container's db and comparing it with the new one obtained by the `fetch` tool. Whatever solution is implemented, it should avoid uploading the db files into this repo.
-4. The DB format of the `oct` tool is coupled to the one that TNF expects, where it should be the other way around (TNF depending on oct's repo) or both repos importing a third repo with the API/scheme only (as TNF does with the [claim file format](https://github.com/test-network-function/test-network-function-claim)).
+4. The DB format of the `oct` tool is coupled to the one that TNF expects, where it should be the other way around (TNF depending on oct's repo) or both repos importing a third repo with the API/scheme only (as TNF does with the [claim file format](https://github.com/redhat-best-practices-for-k8s/certsuite-claim)).
 
 In my opinion, as these certification processes have begun to play important roles in the Red Hat's Ecosystem, this kind of tools shouldn't be needed, as the RH's online catalog could easily provide (a) its own container with this information or (b) a way to download a db.tar.gz with it.

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"time"
 
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/offlinecheck"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"github.com/test-network-function/oct/pkg/certdb/offlinecheck"
 	"gopkg.in/yaml.v3"
 )
 

--- a/cmd/tnf/main.go
+++ b/cmd/tnf/main.go
@@ -4,7 +4,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 
-	"github.com/test-network-function/oct/cmd/tnf/fetch"
+	"github.com/redhat-best-practices-for-k8s/oct/cmd/tnf/fetch"
 )
 
 var (

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/test-network-function/oct
+module github.com/redhat-best-practices-for-k8s/oct
 
 go 1.22.5
 

--- a/pkg/certdb/certdb.go
+++ b/pkg/certdb/certdb.go
@@ -3,9 +3,9 @@ package certdb
 import (
 	"fmt"
 
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/offlinecheck"
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/onlinecheck"
 	"github.com/sirupsen/logrus"
-	"github.com/test-network-function/oct/pkg/certdb/offlinecheck"
-	"github.com/test-network-function/oct/pkg/certdb/onlinecheck"
 	"helm.sh/helm/v3/pkg/release"
 )
 

--- a/pkg/certdb/offlinecheck/container.go
+++ b/pkg/certdb/offlinecheck/container.go
@@ -21,8 +21,8 @@ import (
 	"io"
 	"os"
 
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/config"
 	"github.com/sirupsen/logrus"
-	"github.com/test-network-function/oct/pkg/certdb/config"
 )
 
 var (

--- a/pkg/certdb/onlinecheck/api_test.go
+++ b/pkg/certdb/onlinecheck/api_test.go
@@ -18,8 +18,8 @@ package onlinecheck_test
 import (
 	"testing"
 
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/onlinecheck"
 	"github.com/stretchr/testify/assert"
-	"github.com/test-network-function/oct/pkg/certdb/onlinecheck"
 )
 
 func TestIsContainerCertified(t *testing.T) {

--- a/pkg/certdb/onlinecheck/onlinecheck.go
+++ b/pkg/certdb/onlinecheck/onlinecheck.go
@@ -23,9 +23,9 @@ import (
 	"io"
 	"net/http"
 
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/config"
+	"github.com/redhat-best-practices-for-k8s/oct/pkg/certdb/offlinecheck"
 	log "github.com/sirupsen/logrus"
-	"github.com/test-network-function/oct/pkg/certdb/config"
-	"github.com/test-network-function/oct/pkg/certdb/offlinecheck"
 	yaml "gopkg.in/yaml.v3"
 	"helm.sh/helm/v3/pkg/release"
 )


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2321