### PR TITLE
Use separate credentials for new org

### DIFF
--- a/.github/workflows/recreate-image.yml
+++ b/.github/workflows/recreate-image.yml
@@ -26,7 +26,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@988b5a0280414f521da01fcc63a27aeeb4b104db # v3.6.1
 
-      - name: Authenticate against Quay.io
+      - name: Run endpoint verification script
+        run: |
+          ./scripts/curl-endpoints.sh
+
+      - name: Authenticate against Quay.io (testnetworkfunction)
         uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: quay.io
@@ -35,9 +39,27 @@ jobs:
           username: ${{ secrets.QUAY_ROBOT_USER }}
           password: ${{ secrets.QUAY_ROBOT_TOKEN }}
 
-      - name: Run endpoint verification script
-        run: |
-          ./scripts/curl-endpoints.sh
+      - name: Build and push the latest images for multi-arch (Legacy)
+        uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
+        with:
+          context: .
+          build-args: |
+            TOKEN=${{ secrets.PULL_TOKEN }}
+          file: ./Dockerfile
+          platforms: linux/amd64,linux/arm64
+          no-cache: true
+          push: true
+          tags: |
+            quay.io/testnetworkfunction/oct:latest
+      
+      - name: Authenticate against Quay.io (redhat-best-practices-for-k8s)
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: quay.io
+          # Use a Robot Account to authenticate against Quay.io
+          # https://docs.quay.io/glossary/robot-accounts.html
+          username: ${{ secrets.QUAY_ROBOT_USER_K8S }}
+          password: ${{ secrets.QUAY_ROBOT_TOKEN_K8S }}
 
       - name: Build and push the latest images for multi-arch
         uses: docker/build-push-action@5176d81f87c23d6fc96624dfdbcd9f3830bbe445 # v6.5.0
@@ -50,9 +72,7 @@ jobs:
           no-cache: true
           push: true
           tags: |
-            quay.io/testnetworkfunction/oct:latest
             quay.io/redhat-best-practices-for-k8s/oct:latest
-
 
       - name: If failed to create the image, send alert msg to dev team.
         if: ${{ failure() }}


### PR DESCRIPTION
Build and push both the legacy image and the new image for the new repo.