### PR TITLE
Update GolangCI-lint to v1.60.1

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -121,6 +121,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.59.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	vet
 
 OCT_TOOL_NAME=oct
-GOLANGCI_VERSION=v1.59.1
+GOLANGCI_VERSION=v1.60.1
 
 # Run the unit tests and build all binaries
 build:


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2362