### PR TITLE
Do not consider channel in operator certification

### DIFF
--- a/pkg/certdb/certdb.go
+++ b/pkg/certdb/certdb.go
@@ -11,7 +11,7 @@ import (
 
 type CertificationStatusValidator interface {
 	IsContainerCertified(registry, repository, tag, digest string) bool
-	IsOperatorCertified(csvName, ocpVersion, channel string) bool
+	IsOperatorCertified(csvName, ocpVersion string) bool
 	IsHelmChartCertified(helm *release.Release, ourKubeVersion string) bool
 }
 

--- a/pkg/certdb/offlinecheck/operator.go
+++ b/pkg/certdb/offlinecheck/operator.go
@@ -122,11 +122,11 @@ func loadOperatorsCatalog(pathToRoot string) error {
 // isOperatorCertified check the presence of operator name in certified operators db
 // the operator name is the csv
 // ocpVersion is Major.Minor OCP version
-func (validator OfflineValidator) IsOperatorCertified(csvName, ocpVersion, channel string) bool {
+func (validator OfflineValidator) IsOperatorCertified(csvName, ocpVersion string) bool {
 	name, operatorVersion := ExtractNameVersionFromName(csvName)
 	if v, ok := operatordb[name]; ok {
 		for _, version := range v {
-			if version.operatorVersion == operatorVersion && version.channel == channel {
+			if version.operatorVersion == operatorVersion {
 				if ocpVersion == "" || version.ocpVersion == ocpVersion {
 					log.Trace("operator ", name, " found in db")
 					return true

--- a/pkg/certdb/offlinecheck/operator_test.go
+++ b/pkg/certdb/offlinecheck/operator_test.go
@@ -113,10 +113,9 @@ func TestIsOperatorCertified(t *testing.T) {
 
 	name := "ibm-spectrum-scale-csi-operator.v2.0.0"
 	ocpversion := "4.6"
-	channel := "stable"
 
-	assert.True(t, validator.IsOperatorCertified(name, ocpversion, channel))
+	assert.True(t, validator.IsOperatorCertified(name, ocpversion))
 
 	name = "falcon-alpha"
-	assert.False(t, validator.IsOperatorCertified(name, ocpversion, channel))
+	assert.False(t, validator.IsOperatorCertified(name, ocpversion))
 }

--- a/pkg/certdb/onlinecheck/onlinecheck.go
+++ b/pkg/certdb/onlinecheck/onlinecheck.go
@@ -210,8 +210,8 @@ func (validator OnlineValidator) IsContainerCertified(registry, repository, tag,
 
 // IsOperatorCertified get operator bundle by csv name from the certified-operators org
 // If present then returns `true` if channel and ocp version match.
-func (validator OnlineValidator) IsOperatorCertified(csvName, ocpVersion, channel string) bool {
-	log.Tracef("Searching csv %s (channel %s) for ocp %q", csvName, channel, ocpVersion)
+func (validator OnlineValidator) IsOperatorCertified(csvName, ocpVersion string) bool {
+	log.Tracef("Searching csv %s for ocp %q", csvName, ocpVersion)
 	_, operatorVersion := offlinecheck.ExtractNameVersionFromName(csvName)
 	var responseData []byte
 	var err error
@@ -232,7 +232,7 @@ func (validator OnlineValidator) IsOperatorCertified(csvName, ocpVersion, channe
 		}
 		for _, operator := range operatorEntries.Data {
 			_, opVersion := offlinecheck.ExtractNameVersionFromName(operator.CsvName)
-			if (opVersion == operatorVersion) && (operator.OcpVersion == ocpVersion || ocpVersion == "") && operator.Channel == channel {
+			if (opVersion == operatorVersion) && (operator.OcpVersion == ocpVersion || ocpVersion == "") {
 				return true
 			}
 		}


### PR DESCRIPTION
The channel is an attribute of the catalog, not the operator. If a user is creating a custom catalog and picks a different channel name, the current operator certification will fail, even if the operator is certified. Recommending to remove the channel name from the test logic.