### PR TITLE
Update GolangCI-lint to v1.62.2

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -118,6 +118,6 @@ issues:
 # golangci.com configuration
 # https://github.com/golangci/golangci/wiki/Configuration
 service:
-  golangci-lint-version: 1.60.x # use the fixed version to not introduce new linters unexpectedly
+  golangci-lint-version: 1.62.x # use the fixed version to not introduce new linters unexpectedly
   prepare:
     - echo "here I can run custom commands, but no preparation needed for this repo"

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ GO_PACKAGES=$(shell go list ./... | grep -v vendor)
 	vet
 
 OCT_TOOL_NAME=oct
-GOLANGCI_VERSION=v1.60.3
+GOLANGCI_VERSION=v1.62.2
 
 # Run the unit tests and build all binaries
 build:

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -226,6 +226,9 @@ func getOperatorCatalog(data *CertifiedCatalog) error {
 	}
 
 	log.Infof("Certified operators in the online catalog: %d, page size: %d", total, pageSize)
+	// convert data.Operators to uint to compare with total
+
+	//nolint:gosec
 	if total == uint(data.Operators) {
 		log.Info("No new certified operator found")
 		return nil


### PR DESCRIPTION
Related to: https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2598