### PR TITLE
Add ppc64le and s390x support

### DIFF
--- a/.github/workflows/recreate-image.yml
+++ b/.github/workflows/recreate-image.yml
@@ -46,7 +46,7 @@ jobs:
           build-args: |
             TOKEN=${{ secrets.PULL_TOKEN }}
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           no-cache: true
           push: true
           tags: |
@@ -97,7 +97,7 @@ jobs:
           build-args: |
             TOKEN=${{ secrets.PULL_TOKEN }}
           file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le,linux/s390x
           no-cache: true
           push: true
           tags: |

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.5@sha256:53d6c19d664f4f418ce5c823d3a33dbb562a2550ea249cf07ef10aa063ace38f AS builder
+FROM --platform=$BUILDPLATFORM registry.access.redhat.com/ubi9/ubi:9.5@sha256:53d6c19d664f4f418ce5c823d3a33dbb562a2550ea249cf07ef10aa063ace38f AS builder
 ARG OCT_REPO=github.com/test-network-function/oct.git
 ARG TOKEN
 ENV OCT_FOLDER=/usr/oct


### PR DESCRIPTION
Adds `ppc64le` and `s390x` to the call to build the Dockerfile.

`--platform=$BUILDPLATFORM` on the base image allows for the build environment (x86 in actions, x86/arm64 in dev environments) to run properly.