### PR TITLE
Update Go to v1.24.0; dependabot config update

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,12 +5,17 @@ updates:
   - package-ecosystem: "gomod"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
+    groups:
+      dev-dependencies:
+        dependency-type: "development"
+      prod-dependencies:
+        dependency-type: "production"
   - package-ecosystem: "docker"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
   - package-ecosystem: github-actions
     directory: /
     schedule:
-      interval: daily
+      interval: weekly

--- a/.github/workflows/preflight.yml
+++ b/.github/workflows/preflight.yml
@@ -20,10 +20,10 @@ jobs:
     steps:
       - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
 
-      - name: Set up Go 1.24
+      - name: Set up Go
         uses: actions/setup-go@f111f3307d8850f501ac008e886eec1fd1932a34 # v5.3.0
         with:
-          go-version: 1.24.0
+          go-version-file: go.mod
 
       - name: Disable default go problem matcher
         run: echo "::remove-matcher owner=go::"


### PR DESCRIPTION
Related to: 
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2806
- https://github.com/redhat-best-practices-for-k8s/certsuite/pull/2795