### PR TITLE
ci: pin golangci-lint to v2.12.1 and remove unused nolint directives

### DIFF
--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -35,6 +35,7 @@ jobs:
       - name: Golangci-lint
         uses: golangci/golangci-lint-action@1e7e51e771db61008b38414a730f564565cf7c20 # v9.2.0
         with:
+          version: v2.12.1
           args: --timeout 10m0s
 
       - name: make vet

--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -230,7 +230,6 @@ func getOperatorCatalog(data *CertifiedCatalog) error {
 	log.Infof("Certified operators in the online catalog: %d, page size: %d", total, pageSize)
 	// convert data.Operators to uint to compare with total
 
-	//nolint:gosec
 	if total == uint(data.Operators) {
 		log.Info("No new certified operator found")
 		return nil
@@ -259,7 +258,6 @@ func getOperatorCatalog(data *CertifiedCatalog) error {
 		}
 	}
 
-	//nolint:gosec
 	data.Operators = int(total)
 
 	log.Info("Time to process all the operators: ", time.Since(start))


### PR DESCRIPTION
## Summary
- Pins golangci-lint to v2.12.1 to prevent CI breakage from future releases
- Removes unused `//nolint:gosec` directives in `cmd/tnf/fetch/fetch.go` that v2.12.1 flags as unnecessary (the integer conversions are no longer flagged by gosec)

## Test plan
- [ ] CI lint step passes with pinned version