### PR TITLE
Fix: add the repository field in pyxis query

### DIFF
--- a/cmd/tnf/fetch/fetch.go
+++ b/cmd/tnf/fetch/fetch.go
@@ -21,10 +21,11 @@ const (
 	containersGraphQLIncludeFilter = "data._id," +
 		"data.creation_date," +
 		"data.repositories.registry," +
+		"data.repositories.repository," +
+		"data.repositories.manifest_list_digest," +
 		"data.repositories.tags.name," +
 		"data.image_id," +
-		"data.architecture," +
-		"data.repositories.manifest_list_digest"
+		"data.architecture"
 
 	operatorsGraphQLIncludeFilter = "page," +
 		"page_size," +


### PR DESCRIPTION
PR #427 removed the repository field from the pyxis reponse to container image entries. That field is also necessary for offline check.