### PR TITLE
Recreate Image workflow: restore image tag.

### DIFF
--- a/.github/workflows/recreate-image.yml
+++ b/.github/workflows/recreate-image.yml
@@ -10,7 +10,7 @@ on:
 permissions: read-all
 
 env:
-  IMAGE_TAG: test
+  IMAGE_TAG: latest
   IMAGE_NAME: quay.io/redhat-best-practices-for-k8s/oct
   IMAGE_NAME_LEGACY: quay.io/testnetworkfunction/oct
 


### PR DESCRIPTION
The tag was changed to "test" while doing the tests for improving the db creation. As we're waiting for RH catalog to add and index for updated entries, let's restore the tag to latest so the certsuite can use it again.